### PR TITLE
SFTP Plugin Help

### DIFF
--- a/client/sftp_client.ui
+++ b/client/sftp_client.ui
@@ -203,7 +203,7 @@
                 <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Transfers</property>
                 <attributes>
-                  <attribute name="scale" value="1.1000000000000001"/>
+                  <attribute name="scale" value="1.25"/>
                 </attributes>
               </object>
               <packing>

--- a/client/sftp_client.ui
+++ b/client/sftp_client.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.18.3 -->
+<!-- Generated with glade 3.20.0 -->
 <interface>
   <requires lib="gtk+" version="3.12"/>
   <object class="GtkImage" id="image2">
@@ -127,7 +127,6 @@
                         <property name="receives_default">True</property>
                         <property name="image">image3</property>
                         <property name="use_underline">True</property>
-                        <property name="yalign">0.51999998092651367</property>
                         <property name="always_show_image">True</property>
                       </object>
                       <packing>
@@ -203,6 +202,9 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Transfers</property>
+                <attributes>
+                  <attribute name="scale" value="1.1000000000000001"/>
+                </attributes>
               </object>
               <packing>
                 <property name="expand">False</property>


### PR DESCRIPTION
Everything here can wait, but I need to submit this now or I'll forget later on. I'll also probably add additional changes to this branch as I find time.

Changes to this include:
- [ ] Some Python 3 compatibility fixes (importing of Queue, and exception handling syntax)
- [ ] Rename `treeview_local` to just `treeview` since the `RemoteDirectory` class uses it as well
- [ ] Fix a logic problem in how worker threads are informed to stop<sup>1</sup>
- [ ] ~~Sort the file browser treeviews by filename by default~~
- [ ] Show an error dialog if the SSH connection is unavailable (because King Phisher is connected to the localhost)
- [ ] Added a `get_treeview_column` function to limit repetition
- [ ] Fix a bug where the progress bar was not 100% on Completion
- [ ] Renamed signal handlers to use the `signal_` prefix
- [ ] Handle key presses in the directory treeviews for F2 (rename), F5 (refresh) and Delete
- [ ] Use a `Task` based system with a `TaskQueue` that dispatches tasks in a "Pending" state to worker threads
- [ ] Handle the Upload / Download popup menu items

<sup>1</sup> I'm pretty sure this fixes the bug you mentioned where if the user increased the number of worker threads and doesn't queue as many files, the threads never exit.
